### PR TITLE
feat: forward operator and tail in chat completion payloads

### DIFF
--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -7,7 +7,8 @@
 	import { getContext, tick } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import { chatCompletion } from '$lib/apis/openai';
+        import { chatCompletion } from '$lib/apis/openai';
+        import { settings } from '$lib/stores';
 
 	import ChatBubble from '$lib/components/icons/ChatBubble.svelte';
 	import LightBulb from '$lib/components/icons/LightBulb.svelte';
@@ -53,21 +54,23 @@
 		].join('\n');
 		floatingInputValue = '';
 
-		responseContent = '';
-		const [res, controller] = await chatCompletion(localStorage.token, {
-			model: model,
-			messages: [
-				...messages,
-				{
-					role: 'user',
-					content: prompt
-				}
-			].map((message) => ({
-				role: message.role,
-				content: message.content
-			})),
-			stream: true // Enable streaming
-		});
+                responseContent = '';
+               const [res, controller] = await chatCompletion(localStorage.token, {
+                       model: model,
+                       messages: [
+                               ...messages,
+                               {
+                                       role: 'user',
+                                       content: prompt
+                               }
+                       ].map((message) => ({
+                               role: message.role,
+                               content: message.content
+                       })),
+                       stream: true, // Enable streaming
+                       operator: $settings?.params?.operator,
+                       tail: $settings?.params?.tail
+               });
 
 		if (res && res.ok) {
 			const reader = res.body.getReader();
@@ -133,21 +136,23 @@
 			.join('\n');
 		prompt = `${quotedText}\n\nExplain`;
 
-		responseContent = '';
-		const [res, controller] = await chatCompletion(localStorage.token, {
-			model: model,
-			messages: [
-				...messages,
-				{
-					role: 'user',
-					content: prompt
-				}
-			].map((message) => ({
-				role: message.role,
-				content: message.content
-			})),
-			stream: true // Enable streaming
-		});
+               responseContent = '';
+               const [res, controller] = await chatCompletion(localStorage.token, {
+                       model: model,
+                       messages: [
+                               ...messages,
+                               {
+                                       role: 'user',
+                                       content: prompt
+                               }
+                       ].map((message) => ({
+                               role: message.role,
+                               content: message.content
+                       })),
+                       stream: true, // Enable streaming
+                       operator: $settings?.params?.operator,
+                       tail: $settings?.params?.tail
+               });
 
 		if (res && res.ok) {
 			const reader = res.body.getReader();

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -237,20 +237,22 @@ ${content}
 		note.title = '';
 		titleGenerating = true;
 
-		const res = await generateOpenAIChatCompletion(
-			localStorage.token,
-			{
-				model: selectedModelId,
-				stream: false,
-				messages: [
-					{
-						role: 'user',
-						content: DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
-					}
-				]
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const res = await generateOpenAIChatCompletion(
+                        localStorage.token,
+                        {
+                                model: selectedModelId,
+                                stream: false,
+                                messages: [
+                                        {
+                                                role: 'user',
+                                                content: DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
+                                        }
+                                ],
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 		if (res) {
 			// Step 1: Safely extract the response string
 			const response = res?.choices[0]?.message?.content ?? '';
@@ -672,28 +674,30 @@ Input will be provided within <notes> and <context> XML tags, providing a struct
 Provide the enhanced notes in markdown format. Use markdown syntax for headings, lists, task lists ([ ]) where tasks or checklists are strongly implied, and emphasis to improve clarity and presentation. Ensure that all integrated content from the context is accurately reflected. Return only the markdown formatted note.
 `;
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: [
-					{
-						role: 'system',
-						content: systemPrompt
-					},
-					{
-						role: 'user',
-						content:
-							`<notes>${note.data.content.md}</notes>` +
-							(files && files.length > 0
-								? `\n<context>${files.map((file) => `${file.name}: ${file?.file?.data?.content ?? 'Could not extract content'}\n`).join('')}</context>`
-								: '')
-					}
-				]
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const [res, controller] = await chatCompletion(
+                        localStorage.token,
+                        {
+                                model: model.id,
+                                stream: true,
+                                messages: [
+                                        {
+                                                role: 'system',
+                                                content: systemPrompt
+                                        },
+                                        {
+                                                role: 'user',
+                                                content:
+                                                        `<notes>${note.data.content.md}</notes>` +
+                                                        (files && files.length > 0
+                                                                ? `\n<context>${files.map((file) => `${file.name}: ${file?.file?.data?.content ?? 'Could not extract content'}\n`).join('')}</context>`
+                                                                : '')
+                                        }
+                                ],
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 
 		await tick();
 

--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -184,16 +184,18 @@ Based on the user's instruction, update and enhance the existing notes or select
 			])
 		);
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: chatMessages
-				// ...(files && files.length > 0 ? { files } : {}) // TODO: Decide whether to use native file handling or not
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const [res, controller] = await chatCompletion(
+                        localStorage.token,
+                        {
+                                model: model.id,
+                                stream: true,
+                                messages: chatMessages,
+                                // ...(files && files.length > 0 ? { files } : {}) // TODO: Decide whether to use native file handling or not
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 
 		await tick();
 		scrollToBottom();

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -83,23 +83,25 @@
 			return;
 		}
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: [
-					system
-						? {
-								role: 'system',
-								content: system
-							}
-						: undefined,
-					...messages
-				].filter((message) => message)
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+               const [res, controller] = await chatCompletion(
+                       localStorage.token,
+                       {
+                               model: model.id,
+                               stream: true,
+                               messages: [
+                                       system
+                                               ? {
+                                                               role: 'system',
+                                                               content: system
+                                                       }
+                                               : undefined,
+                                       ...messages
+                               ].filter((message) => message),
+                               operator: $settings?.params?.operator,
+                               tail: $settings?.params?.tail
+                       },
+                       `${WEBUI_BASE_URL}/api`
+               );
 
 		let responseMessage;
 		if (messages.at(-1)?.role === 'assistant') {

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -37,23 +37,25 @@
 		console.log('stopResponse');
 	};
 
-	const textCompletionHandler = async () => {
-		const model = $models.find((model) => model.id === selectedModelId);
+        const textCompletionHandler = async () => {
+                const model = $models.find((model) => model.id === selectedModelId);
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: [
-					{
-						role: 'assistant',
-						content: text
-					}
-				]
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const [res, controller] = await chatCompletion(
+                        localStorage.token,
+                        {
+                                model: model.id,
+                                stream: true,
+                                messages: [
+                                        {
+                                                role: 'assistant',
+                                                content: text
+                                        }
+                                ],
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 
 		if (res && res.ok) {
 			const reader = res.body


### PR DESCRIPTION
## Summary
- include `operator` and `tail` in chat payloads so they are forwarded to the backend
- update playground and note editor helpers to send the new fields
- backend routes already forward unknown fields to target models

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6891dfada6b48332b8609eb9441ec797