### PR TITLE
feat: forward operator and tail in chat completion payloads

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -179,13 +179,19 @@
 						messageInput?.setText(input.prompt);
 						files = input.files;
 						selectedToolIds = input.selectedToolIds;
-						selectedFilterIds = input.selectedFilterIds;
-						webSearchEnabled = input.webSearchEnabled;
-						imageGenerationEnabled = input.imageGenerationEnabled;
-						codeInterpreterEnabled = input.codeInterpreterEnabled;
-					}
-				} catch (e) {}
-			}
+                                                selectedFilterIds = input.selectedFilterIds;
+                                                webSearchEnabled = input.webSearchEnabled;
+                                                imageGenerationEnabled = input.imageGenerationEnabled;
+                                                codeInterpreterEnabled = input.codeInterpreterEnabled;
+                                                if (input.operator !== undefined) {
+                                                        params.operator = input.operator;
+                                                }
+                                                if (input.tail !== undefined) {
+                                                        params.tail = input.tail;
+                                                }
+                                        }
+                                } catch (e) {}
+                        }
 
 			const chatInput = document.getElementById('chat-input');
 			chatInput?.focus();
@@ -493,13 +499,19 @@
 					messageInput?.setText(input.prompt);
 					files = input.files;
 					selectedToolIds = input.selectedToolIds;
-					selectedFilterIds = input.selectedFilterIds;
-					webSearchEnabled = input.webSearchEnabled;
-					imageGenerationEnabled = input.imageGenerationEnabled;
-					codeInterpreterEnabled = input.codeInterpreterEnabled;
-				}
-			} catch (e) {}
-		}
+                                        selectedFilterIds = input.selectedFilterIds;
+                                        webSearchEnabled = input.webSearchEnabled;
+                                        imageGenerationEnabled = input.imageGenerationEnabled;
+                                        codeInterpreterEnabled = input.codeInterpreterEnabled;
+                                        if (input.operator !== undefined) {
+                                                params.operator = input.operator;
+                                        }
+                                        if (input.tail !== undefined) {
+                                                params.tail = input.tail;
+                                        }
+                                }
+                        } catch (e) {}
+                }
 
 		showControls.subscribe(async (value) => {
 			if (controlPane && !$mobile) {
@@ -1680,35 +1692,44 @@
 			}))
 			.filter((message) => message?.role === 'user' || message?.content?.trim());
 
-		const res = await generateOpenAIChatCompletion(
-			localStorage.token,
-			{
-				stream: stream,
-				model: model.id,
-				messages: messages,
-				params: {
-					...$settings?.params,
-					...params,
-					stop:
-						(params?.stop ?? $settings?.params?.stop ?? undefined)
-							? (params?.stop.split(',').map((token) => token.trim()) ?? $settings.params.stop).map(
-									(str) => decodeURIComponent(JSON.parse('"' + str.replace(/\"/g, '\\"') + '"'))
-								)
-							: undefined
-				},
+               const mergedParams = { ...$settings?.params, ...params };
+               const { operator, tail, stop, ...restParams } = mergedParams;
+               const formattedStop = stop
+                       ? stop
+                                       .split(',')
+                                       .map((token) => token.trim())
+                                       .map((str) =>
+                                               decodeURIComponent(
+                                                       JSON.parse('"' + str.replace(/\"/g, '\\"') + '"')
+                                               )
+                                       )
+                       : undefined;
 
-				files: (files?.length ?? 0) > 0 ? files : undefined,
+               const res = await generateOpenAIChatCompletion(
+                       localStorage.token,
+                       {
+                               stream: stream,
+                               model: model.id,
+                               messages: messages,
+                               operator: operator,
+                               tail: tail,
+                               params: {
+                                       ...restParams,
+                                       ...(formattedStop ? { stop: formattedStop } : {})
+                               },
 
-				filter_ids: selectedFilterIds.length > 0 ? selectedFilterIds : undefined,
-				tool_ids: selectedToolIds.length > 0 ? selectedToolIds : undefined,
-				tool_servers: $toolServers,
+                               files: (files?.length ?? 0) > 0 ? files : undefined,
 
-				features: {
-					image_generation:
-						$config?.features?.enable_image_generation &&
-						($user?.role === 'admin' || $user?.permissions?.features?.image_generation)
-							? imageGenerationEnabled
-							: false,
+                               filter_ids: selectedFilterIds.length > 0 ? selectedFilterIds : undefined,
+                               tool_ids: selectedToolIds.length > 0 ? selectedToolIds : undefined,
+                               tool_servers: $toolServers,
+
+                               features: {
+                                       image_generation:
+                                               $config?.features?.enable_image_generation &&
+                                               ($user?.role === 'admin' || $user?.permissions?.features?.image_generation)
+                                                       ? imageGenerationEnabled
+                                                       : false,
 					code_interpreter:
 						$config?.features?.enable_code_interpreter &&
 						($user?.role === 'admin' || $user?.permissions?.features?.code_interpreter)
@@ -2161,13 +2182,14 @@
 									bind:prompt
 									bind:autoScroll
 									bind:selectedToolIds
-									bind:selectedFilterIds
-									bind:imageGenerationEnabled
-									bind:codeInterpreterEnabled
-									bind:webSearchEnabled
-									bind:atSelectedModel
-									bind:showCommands
-									toolServers={$toolServers}
+                                                                        bind:selectedFilterIds
+                                                                        bind:imageGenerationEnabled
+                                                                        bind:codeInterpreterEnabled
+                                                                        bind:webSearchEnabled
+                                                                        bind:params
+                                                                        bind:atSelectedModel
+                                                                        bind:showCommands
+                                                                        toolServers={$toolServers}
 									transparentBackground={$settings?.backgroundImageUrl ??
 										$config?.license_metadata?.background_image_url ??
 										false}
@@ -2224,15 +2246,16 @@
 									bind:prompt
 									bind:autoScroll
 									bind:selectedToolIds
-									bind:selectedFilterIds
-									bind:imageGenerationEnabled
-									bind:codeInterpreterEnabled
-									bind:webSearchEnabled
-									bind:atSelectedModel
-									bind:showCommands
-									transparentBackground={$settings?.backgroundImageUrl ??
-										$config?.license_metadata?.background_image_url ??
-										false}
+                                                                       bind:selectedFilterIds
+                                                                       bind:imageGenerationEnabled
+                                                                       bind:codeInterpreterEnabled
+                                                                       bind:webSearchEnabled
+                                                                       bind:params
+                                                                       bind:atSelectedModel
+                                                                       bind:showCommands
+                                                                       transparentBackground={$settings?.backgroundImageUrl ??
+                                                                               $config?.license_metadata?.background_image_url ??
+                                                                               false}
 									toolServers={$toolServers}
 									{stopResponse}
 									{createMessagePair}

--- a/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
+++ b/src/lib/components/chat/ContentRenderer/FloatingButtons.svelte
@@ -7,7 +7,8 @@
 	import { getContext, tick } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import { chatCompletion } from '$lib/apis/openai';
+        import { chatCompletion } from '$lib/apis/openai';
+        import { settings } from '$lib/stores';
 
 	import ChatBubble from '$lib/components/icons/ChatBubble.svelte';
 	import LightBulb from '$lib/components/icons/LightBulb.svelte';
@@ -53,21 +54,23 @@
 		].join('\n');
 		floatingInputValue = '';
 
-		responseContent = '';
-		const [res, controller] = await chatCompletion(localStorage.token, {
-			model: model,
-			messages: [
-				...messages,
-				{
-					role: 'user',
-					content: prompt
-				}
-			].map((message) => ({
-				role: message.role,
-				content: message.content
-			})),
-			stream: true // Enable streaming
-		});
+                responseContent = '';
+               const [res, controller] = await chatCompletion(localStorage.token, {
+                       model: model,
+                       messages: [
+                               ...messages,
+                               {
+                                       role: 'user',
+                                       content: prompt
+                               }
+                       ].map((message) => ({
+                               role: message.role,
+                               content: message.content
+                       })),
+                       stream: true, // Enable streaming
+                       operator: $settings?.params?.operator,
+                       tail: $settings?.params?.tail
+               });
 
 		if (res && res.ok) {
 			const reader = res.body.getReader();
@@ -133,21 +136,23 @@
 			.join('\n');
 		prompt = `${quotedText}\n\nExplain`;
 
-		responseContent = '';
-		const [res, controller] = await chatCompletion(localStorage.token, {
-			model: model,
-			messages: [
-				...messages,
-				{
-					role: 'user',
-					content: prompt
-				}
-			].map((message) => ({
-				role: message.role,
-				content: message.content
-			})),
-			stream: true // Enable streaming
-		});
+               responseContent = '';
+               const [res, controller] = await chatCompletion(localStorage.token, {
+                       model: model,
+                       messages: [
+                               ...messages,
+                               {
+                                       role: 'user',
+                                       content: prompt
+                               }
+                       ].map((message) => ({
+                               role: message.role,
+                               content: message.content
+                       })),
+                       stream: true, // Enable streaming
+                       operator: $settings?.params?.operator,
+                       tail: $settings?.params?.tail
+               });
 
 		if (res && res.ok) {
 			const reader = res.body.getReader();

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -101,7 +101,20 @@
 
 	export let imageGenerationEnabled = false;
 	export let webSearchEnabled = false;
-	export let codeInterpreterEnabled = false;
+        export let codeInterpreterEnabled = false;
+
+        // Forward params such as operator and tail
+        export let params = {};
+
+        // basic dropdown options; can be customized via settings if needed
+        const operatorOptions = ['openai', 'anthropic', 'mistral'];
+        const tailOptions = ['fast', 'balanced', 'quality'];
+
+        let operator = params.operator ?? '';
+        let tail = params.tail ?? '';
+
+        $: params.operator = operator;
+        $: params.tail = tail;
 
 	let showInputVariablesModal = false;
 	let inputVariables = {};
@@ -118,12 +131,15 @@
 					access_control: undefined
 				};
 			}),
-		selectedToolIds,
-		selectedFilterIds,
-		imageGenerationEnabled,
-		webSearchEnabled,
-		codeInterpreterEnabled
-	});
+                selectedToolIds,
+                selectedFilterIds,
+                imageGenerationEnabled,
+                webSearchEnabled,
+                codeInterpreterEnabled,
+                operator,
+                tail,
+                params
+        });
 
 	const inputVariableHandler = async (text: string) => {
 		inputVariables = extractInputVariables(text);
@@ -1762,11 +1778,31 @@
 																>{$i18n.t('Code Interpreter')}</span
 															>
 														</button>
-													</Tooltip>
-												{/if}
-											</div>
-										{/if}
-									</div>
+                                                                                                        </Tooltip>
+                                                                                                {/if}
+
+                                                                                                <select
+                                                                                                        bind:value={operator}
+                                                                                                        class="ml-1 px-2 @xl:px-2.5 py-2 text-sm rounded-full border border-gray-200 dark:border-gray-700 bg-transparent text-gray-600 dark:text-gray-300"
+                                                                                                >
+                                                                                                        <option value="">{$i18n.t('Operator')}</option>
+                                                                                                        {#each operatorOptions as option}
+                                                                                                                <option value={option}>{option}</option>
+                                                                                                        {/each}
+                                                                                                </select>
+
+                                                                                                <select
+                                                                                                        bind:value={tail}
+                                                                                                        class="ml-1 px-2 @xl:px-2.5 py-2 text-sm rounded-full border border-gray-200 dark:border-gray-700 bg-transparent text-gray-600 dark:text-gray-300"
+                                                                                                >
+                                                                                                        <option value="">{$i18n.t('Tail')}</option>
+                                                                                                        {#each tailOptions as option}
+                                                                                                                <option value={option}>{option}</option>
+                                                                                                        {/each}
+                                                                                                </select>
+                                                                                        </div>
+                                                                                {/if}
+                                                                        </div>
 
 									<div class="self-end flex space-x-1 mr-1 shrink-0">
 										{#if (!history?.currentId || history.messages[history.currentId]?.done == true) && ($_user?.role === 'admin' || ($_user?.permissions?.chat?.stt ?? true))}

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -48,11 +48,13 @@
 	export let selectedToolIds = [];
 	export let selectedFilterIds = [];
 
-	export let showCommands = false;
+       export let showCommands = false;
 
-	export let imageGenerationEnabled = false;
-	export let codeInterpreterEnabled = false;
-	export let webSearchEnabled = false;
+       export let imageGenerationEnabled = false;
+       export let codeInterpreterEnabled = false;
+       export let webSearchEnabled = false;
+
+        export let params = {};
 
 	export let onSelect = (e) => {};
 
@@ -213,13 +215,14 @@
 					bind:prompt
 					bind:autoScroll
 					bind:selectedToolIds
-					bind:selectedFilterIds
-					bind:imageGenerationEnabled
-					bind:codeInterpreterEnabled
-					bind:webSearchEnabled
-					bind:atSelectedModel
-					bind:showCommands
-					{toolServers}
+                                        bind:selectedFilterIds
+                                        bind:imageGenerationEnabled
+                                        bind:codeInterpreterEnabled
+                                        bind:webSearchEnabled
+                                        bind:params
+                                        bind:atSelectedModel
+                                        bind:showCommands
+                                        {toolServers}
 					{transparentBackground}
 					{stopResponse}
 					{createMessagePair}

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -237,20 +237,22 @@ ${content}
 		note.title = '';
 		titleGenerating = true;
 
-		const res = await generateOpenAIChatCompletion(
-			localStorage.token,
-			{
-				model: selectedModelId,
-				stream: false,
-				messages: [
-					{
-						role: 'user',
-						content: DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
-					}
-				]
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const res = await generateOpenAIChatCompletion(
+                        localStorage.token,
+                        {
+                                model: selectedModelId,
+                                stream: false,
+                                messages: [
+                                        {
+                                                role: 'user',
+                                                content: DEFAULT_TITLE_GENERATION_PROMPT_TEMPLATE
+                                        }
+                                ],
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 		if (res) {
 			// Step 1: Safely extract the response string
 			const response = res?.choices[0]?.message?.content ?? '';
@@ -672,28 +674,30 @@ Input will be provided within <notes> and <context> XML tags, providing a struct
 Provide the enhanced notes in markdown format. Use markdown syntax for headings, lists, task lists ([ ]) where tasks or checklists are strongly implied, and emphasis to improve clarity and presentation. Ensure that all integrated content from the context is accurately reflected. Return only the markdown formatted note.
 `;
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: [
-					{
-						role: 'system',
-						content: systemPrompt
-					},
-					{
-						role: 'user',
-						content:
-							`<notes>${note.data.content.md}</notes>` +
-							(files && files.length > 0
-								? `\n<context>${files.map((file) => `${file.name}: ${file?.file?.data?.content ?? 'Could not extract content'}\n`).join('')}</context>`
-								: '')
-					}
-				]
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const [res, controller] = await chatCompletion(
+                        localStorage.token,
+                        {
+                                model: model.id,
+                                stream: true,
+                                messages: [
+                                        {
+                                                role: 'system',
+                                                content: systemPrompt
+                                        },
+                                        {
+                                                role: 'user',
+                                                content:
+                                                        `<notes>${note.data.content.md}</notes>` +
+                                                        (files && files.length > 0
+                                                                ? `\n<context>${files.map((file) => `${file.name}: ${file?.file?.data?.content ?? 'Could not extract content'}\n`).join('')}</context>`
+                                                                : '')
+                                        }
+                                ],
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 
 		await tick();
 

--- a/src/lib/components/notes/NoteEditor/Chat.svelte
+++ b/src/lib/components/notes/NoteEditor/Chat.svelte
@@ -184,16 +184,18 @@ Based on the user's instruction, update and enhance the existing notes or select
 			])
 		);
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: chatMessages
-				// ...(files && files.length > 0 ? { files } : {}) // TODO: Decide whether to use native file handling or not
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const [res, controller] = await chatCompletion(
+                        localStorage.token,
+                        {
+                                model: model.id,
+                                stream: true,
+                                messages: chatMessages,
+                                // ...(files && files.length > 0 ? { files } : {}) // TODO: Decide whether to use native file handling or not
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 
 		await tick();
 		scrollToBottom();

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -83,23 +83,25 @@
 			return;
 		}
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: [
-					system
-						? {
-								role: 'system',
-								content: system
-							}
-						: undefined,
-					...messages
-				].filter((message) => message)
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+               const [res, controller] = await chatCompletion(
+                       localStorage.token,
+                       {
+                               model: model.id,
+                               stream: true,
+                               messages: [
+                                       system
+                                               ? {
+                                                               role: 'system',
+                                                               content: system
+                                                       }
+                                               : undefined,
+                                       ...messages
+                               ].filter((message) => message),
+                               operator: $settings?.params?.operator,
+                               tail: $settings?.params?.tail
+                       },
+                       `${WEBUI_BASE_URL}/api`
+               );
 
 		let responseMessage;
 		if (messages.at(-1)?.role === 'assistant') {

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -37,23 +37,25 @@
 		console.log('stopResponse');
 	};
 
-	const textCompletionHandler = async () => {
-		const model = $models.find((model) => model.id === selectedModelId);
+        const textCompletionHandler = async () => {
+                const model = $models.find((model) => model.id === selectedModelId);
 
-		const [res, controller] = await chatCompletion(
-			localStorage.token,
-			{
-				model: model.id,
-				stream: true,
-				messages: [
-					{
-						role: 'assistant',
-						content: text
-					}
-				]
-			},
-			`${WEBUI_BASE_URL}/api`
-		);
+                const [res, controller] = await chatCompletion(
+                        localStorage.token,
+                        {
+                                model: model.id,
+                                stream: true,
+                                messages: [
+                                        {
+                                                role: 'assistant',
+                                                content: text
+                                        }
+                                ],
+                                operator: $settings?.params?.operator,
+                                tail: $settings?.params?.tail
+                        },
+                        `${WEBUI_BASE_URL}/api`
+                );
 
 		if (res && res.ok) {
 			const reader = res.body


### PR DESCRIPTION
## Summary
- include `operator` and `tail` in chat payloads so they are forwarded to the backend
- update playground and note editor helpers to send the new fields
- backend routes already forward unknown fields to target models
- add dropdowns for `operator` and `tail` next to the code interpreter toggle and wire them through message inputs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:frontend` *(fails: vitest: not found)*
- `npm run lint:frontend` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6891dfada6b48332b8609eb9441ec797